### PR TITLE
Added a .editorconfig file and put in settings to match the current s…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+# EditorConfig file for BigRational solution: 
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# options for every file
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# options for source files
+[*.{cs,xaml,cpp,h}]
+indent_style = tab
+indent_size = 4
+
+#options for C# files
+[*.cs]
+csharp_space_after_keywords_in_control_flow_statements = true
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+dotnet_naming_style.non_public_field.required_prefix = _
+dotnet_naming_style.non_public_field.capitalization = camel_case
+dotnet_naming_symbols.fields.applicable_kinds = field
+dotnet_naming_symbols.fields.applicable_accessibilities = private,protected
+dotnet_naming_rule.non_public_fields_must_have_underscore_prefix.severity = suggestion
+dotnet_naming_rule.non_public_fields_must_have_underscore_prefix.symbols = fields
+dotnet_naming_rule.non_public_fields_must_have_underscore_prefix.style = non_public_field
+
+
+
+

--- a/BigRational/BigRational.cs
+++ b/BigRational/BigRational.cs
@@ -264,27 +264,27 @@ namespace ExtendedNumerics
 					value.FractionalPart.Denominator
 				));
 		}
-		
+
 		public static BigRational Parse(string value)
 		{
-		    string[] parts = value.Split('/');
-		    if (parts.Length != 2)
-		    {
-			throw new Exception("Invalid fraction given as string to parse.");
-		    }
+			string[] parts = value.Split('/');
+			if (parts.Length != 2)
+			{
+				throw new Exception("Invalid fraction given as string to parse.");
+			}
 
-		    BigInteger numerator, denominator;
-		    try
-		    {
-			numerator = BigInteger.Parse(parts[0]);
-			denominator = BigInteger.Parse(parts[1]);
-		    }
-		    catch
-		    {
-			throw new Exception("Invalid string given for numerator or denominator.");
-		    }
+			BigInteger numerator, denominator;
+			try
+			{
+				numerator = BigInteger.Parse(parts[0]);
+				denominator = BigInteger.Parse(parts[1]);
+			}
+			catch
+			{
+				throw new Exception("Invalid string given for numerator or denominator.");
+			}
 
-		    return new BigRational(BigInteger.Zero, numerator, denominator);
+			return new BigRational(BigInteger.Zero, numerator, denominator);
 		}
 
 		#endregion
@@ -481,8 +481,9 @@ namespace ExtendedNumerics
 
 			return string.Concat(first, join, second);
 		}
-		
+
 		#endregion
 
 	}
 }
+

--- a/BigRational/Fraction.cs
+++ b/BigRational/Fraction.cs
@@ -497,7 +497,7 @@ namespace ExtendedNumerics
 		{
 			BigInteger numer = value.Numerator;
 			BigInteger denom = value.Denominator;
-			
+
 			if (numer.Sign == 1 && denom.Sign == 1)
 			{
 				return value;
@@ -506,7 +506,7 @@ namespace ExtendedNumerics
 			{
 				return value;
 			}
-			else if(numer.Sign == 1 && denom.Sign == -1)
+			else if (numer.Sign == 1 && denom.Sign == -1)
 			{
 				numer = BigInteger.Negate(numer);
 				denom = BigInteger.Negate(denom);
@@ -516,7 +516,7 @@ namespace ExtendedNumerics
 				numer = BigInteger.Negate(numer);
 				denom = BigInteger.Negate(denom);
 			}
-				
+
 			return new Fraction(numer, denom);
 		}
 
@@ -578,3 +578,4 @@ namespace ExtendedNumerics
 		#endregion
 	}
 }
+


### PR DESCRIPTION
…tyle of the code. This will help other contributors match the current code style. I also ran an automatic formatting pass over the current source files to make sure they match.

I was working on some other functionality and committed the code, then I noticed I had used spaces whereas your code had used tabs. This annoyed me as I would have to redo my commits with the proper indentation method. So this doesn't happen again I have added the tab indentation as the default in the .editorconfig file. Visual Studio 2017 onwards automatically picks up this configuration file.