### PR TITLE
Added Muller's Recurrence test, to check that BigRational is holding …

### DIFF
--- a/BigRational/BigRational.cs
+++ b/BigRational/BigRational.cs
@@ -164,6 +164,8 @@ namespace ExtendedNumerics
 			return new BigRational(BigInteger.Zero, new Fraction(remainder, divisor));
 		}
 
+		public static BigRational operator +(BigRational augend, BigRational addend) => Add(augend, addend);
+
 		public static BigRational Add(BigRational augend, BigRational addend)
 		{
 			Fraction fracAugend = augend.GetImproperFraction();
@@ -174,6 +176,8 @@ namespace ExtendedNumerics
 			return reduced;
 		}
 
+		public static BigRational operator -(BigRational minuend, BigRational subtrahend) => Subtract(minuend, subtrahend);
+
 		public static BigRational Subtract(BigRational minuend, BigRational subtrahend)
 		{
 			Fraction fracMinuend = minuend.GetImproperFraction();
@@ -183,6 +187,8 @@ namespace ExtendedNumerics
 			BigRational reduced = BigRational.Reduce(result);
 			return reduced;
 		}
+
+		public static BigRational operator *(BigRational multiplicand, BigRational multiplier) => Multiply(multiplicand, multiplier);
 
 		public static BigRational Multiply(BigRational multiplicand, BigRational multiplier)
 		{
@@ -206,6 +212,8 @@ namespace ExtendedNumerics
 
 			return result;
 		}
+
+		public static BigRational operator /(BigRational dividend, BigRational divisor) => Divide(dividend, divisor);
 
 		public static BigRational Divide(BigRational dividend, BigRational divisor)
 		{

--- a/TestBigRational/TestBigRational.cs
+++ b/TestBigRational/TestBigRational.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Numerics;
 using ExtendedNumerics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -149,5 +150,46 @@ namespace TestBigRational
 			Assert.AreEqual(expectedNeg317, result3);
 			Assert.AreEqual(expected7over1, result7);
 		}
+
+		[TestMethod]
+		public void TestMullersRecurrenceConvergesOnFive()
+		{
+			// Set an upper limit to the number of iterations to be tried
+			int n = 100;
+
+			// Precreate some constants to use in the calculations
+			BigRational c108 = new BigRational(108);
+			BigRational c815 = new BigRational(815);
+			BigRational c1500 = new BigRational(1500);
+			BigRational convergencePoint = new BigRational(5);
+
+			// Seed the initial values
+			BigRational X0 = new BigRational(4);
+			BigRational X1 = new BigRational(new Fraction(17, 4));
+			BigRational Xprevious = X0;
+			BigRational Xn = X1;
+
+			// Get the current distance to the convergence point, this should be constantly
+			// decreasing with each iteration
+			BigRational distanceToConvergence = BigRational.Subtract(convergencePoint, X1);
+
+			int count = 1;
+			for (int i = 1; i < n; ++i)
+			{
+				BigRational Xnext = c108 - (c815 - c1500 / Xprevious) / Xn;
+				BigRational nextDistanceToConvergence = BigRational.Subtract(convergencePoint, Xnext);
+				Assert.IsTrue(nextDistanceToConvergence < distanceToConvergence);
+
+				Xprevious = Xn;
+				Xn = Xnext;
+				distanceToConvergence = nextDistanceToConvergence;
+				if ((Double)Xn == 5d)
+					break;
+				++count;
+			}
+			Assert.AreEqual((Double)Xn, 5d);
+			Assert.IsTrue(count == 70);
+		}
+
 	}
 }


### PR DESCRIPTION
…accuracy over many iterations.

Here's a link to explain https://scipython.com/blog/mullers-recurrence/

Needed to add some operators to cut down on the verboseness of the test. Trying to use the Divide and Subtract functions on a complex equation made the equation difficult for a human to parse.

This is the current equation:

`BigRational Xnext = c108 - (c815 - c1500 / Xprevious) / Xn;`

Without the operator overloads it looked like this, which took me a while to get right as I made a few mistakes the first time I typed it in:

`BigRational Xnext = BigRational.Subtract(c108,BigRational.Divide(BigRational.Subtract(c815, BigRational.Divide(c1500,Xprevious))), Xn);`