### PR TITLE
Added in support for Decimal type

### DIFF
--- a/BigRational/BigRational.cs
+++ b/BigRational/BigRational.cs
@@ -71,6 +71,30 @@ namespace ExtendedNumerics
 			}
 		}
 
+		public BigRational(Decimal value)
+		{
+			switch (value)
+			{
+				case Decimal.Zero:
+					WholePart = BigInteger.Zero;
+					FractionalPart = Fraction.One;
+					break;
+				case Decimal.One:
+					WholePart = BigInteger.Zero;
+					FractionalPart = Fraction.One;
+					break;
+				case Decimal.MinusOne:
+					WholePart = BigInteger.Zero;
+					FractionalPart = Fraction.MinusOne;
+					break;
+				default:
+					WholePart = (BigInteger)Math.Truncate(value);
+					Decimal fract = Math.Abs(value) % 1;
+					FractionalPart = (fract == 0) ? Fraction.Zero : new Fraction(fract);
+					break;
+			}
+		}
+
 		#endregion
 
 		#region Properties
@@ -243,8 +267,17 @@ namespace ExtendedNumerics
 
 		#region Conversion
 
+		public static explicit operator BigRational(Int32 value)
+		{
+			return new BigRational(value);
+		}
 
 		public static explicit operator BigRational(Double value)
+		{
+			return new BigRational(value);
+		}
+
+		public static explicit operator BigRational(Decimal value)
 		{
 			return new BigRational(value);
 		}

--- a/TestBigRational/TestBigRational.cs
+++ b/TestBigRational/TestBigRational.cs
@@ -102,10 +102,49 @@ namespace TestBigRational
 		[TestMethod]
 		public void TestConvertFromNegativeMixedDouble()
 		{
-			Double negativeOneAndOneThird = -((double)4 / (double)3);
+			Double negativeOneAndOneThird = -4d / 3d;
 
 			BigRational expectedValue = new BigRational(-1, new Fraction(1, 3));
 			BigRational result = (BigRational)negativeOneAndOneThird;
+
+			Assert.AreEqual(expectedValue, result);
+		}
+
+		[TestMethod]
+		public void TestConvertFromDecimalPointDecimal()
+		{
+			Decimal fifteenSixteenths = 0.9375m;
+
+			BigRational expectedValue = new BigRational(BigInteger.Zero, new Fraction(15, 16));
+			BigRational result = (BigRational)fifteenSixteenths;
+
+			Assert.AreEqual(expectedValue, result);
+		}
+
+		[TestMethod]
+		public void TestConvertFromWholeNumberDecimal()
+		{
+			Decimal seven = 7.0m;
+
+			BigRational expectedValue = new BigRational(7, new Fraction(0, 1));
+
+			BigRational result1 = new BigRational(seven);
+			BigRational result2 = (BigRational)seven;
+
+
+			Assert.AreEqual(expectedValue, result1);
+			Assert.AreEqual(expectedValue, result2);
+		}
+
+		[TestMethod]
+		public void TestConvertFromNegativeMixedDecimal()
+		{
+			// Note that Decimal works best with a fixed number of decimal points
+			// This will fail if we use the same numbers as used with the double test
+			Decimal negativeOneAndOneHundredAndTwentyEigth = -129m / 128m;
+
+			BigRational expectedValue = new BigRational(-1, new Fraction(1, 128));
+			BigRational result = (BigRational)negativeOneAndOneHundredAndTwentyEigth;
 
 			Assert.AreEqual(expectedValue, result);
 		}

--- a/TestBigRational/TestFraction.cs
+++ b/TestBigRational/TestFraction.cs
@@ -132,6 +132,39 @@ namespace TestBigRational
 		}
 
 		[TestMethod]
+		public void TestConvertToDecimal()
+		{
+			Fraction oneSixteenth = new Fraction(1, 16);
+			Fraction negativeOneThird = new Fraction(-1, 3);
+
+			Decimal expectedValueOneSixteenth = 0.0625m;
+			Decimal expectedValueNegativeOneThird = -1m / 3m;
+
+			Decimal resultOneSixteenth = (Decimal)oneSixteenth;
+			Decimal resultNegativeOneThird = (Decimal)negativeOneThird;
+
+			Assert.AreEqual(expectedValueOneSixteenth, resultOneSixteenth);
+			Assert.AreEqual(expectedValueNegativeOneThird, resultNegativeOneThird);
+		}
+
+		[TestMethod]
+		public void TestConvertFromDecimal()
+		{
+			// Decimal converts best with a fixed number of decimal points
+			Decimal fifteenSixteenths = 0.9375m;
+			Decimal negativeOneOneHundredAndTwentyEight = -1m / 128m;
+
+			Fraction expectedValueFifteenSixteenths = new Fraction(15, 16);
+			Fraction expectedValueNegativeOneThird = new Fraction(-1, 128);
+
+			Fraction result1516 = (Fraction)fifteenSixteenths;
+			Fraction resultNeg1128 = (Fraction)negativeOneOneHundredAndTwentyEight;
+
+			Assert.AreEqual(expectedValueFifteenSixteenths, result1516);
+			Assert.AreEqual(expectedValueNegativeOneThird, resultNeg1128);
+		}
+
+		[TestMethod]
 		public void TestSimplify()
 		{
 			Fraction eighteenTwos = new Fraction(18, 2);


### PR DESCRIPTION
Without BigRational the only way to do financial calculations without having rounding errors was to use the Decimal type. BigRational extends this capability to an arbitrary number of decimal places. As such it is a natural extension of the Decimal type and should support conversions to and from current code that uses the Decimal type.

This pull request adds support for the Decimal type, and adds some tests for the conversion.