### PR TITLE
Comparisons on numeric type

### DIFF
--- a/BigRational.sln
+++ b/BigRational.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BigRational", "BigRational\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestBigRational", "TestBigRational\TestBigRational.csproj", "{F1589DA8-F936-43A5-AFDD-00431C955262}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{2C46E364-C1D1-47A0-B2ED-3A6103AEECF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MullersReucrrenceExample", "Examples\MullersReucrrenceExample\MullersReucrrenceExample.csproj", "{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,8 +25,18 @@ Global
 		{F1589DA8-F936-43A5-AFDD-00431C955262}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1589DA8-F936-43A5-AFDD-00431C955262}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1589DA8-F936-43A5-AFDD-00431C955262}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9D9EF991-5E69-4B10-ACA7-0C0013E856B0} = {2C46E364-C1D1-47A0-B2ED-3A6103AEECF9}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {938ADF40-8BCC-496C-B07A-8EAE6F8DE9E3}
 	EndGlobalSection
 EndGlobal

--- a/BigRational/BigRational.cs
+++ b/BigRational/BigRational.cs
@@ -299,6 +299,14 @@ namespace ExtendedNumerics
 			return result;
 		}
 
+		public static explicit operator Decimal(BigRational value)
+		{
+			Decimal fract = (Decimal)value.FractionalPart;
+			Decimal whole = (Decimal)value.WholePart;
+			Decimal result = whole + (fract);
+			return result;
+		}
+
 		public static explicit operator Fraction(BigRational value)
 		{
 			return Fraction.Simplify(new Fraction(

--- a/Examples/MullersReucrrenceExample/App.config
+++ b/Examples/MullersReucrrenceExample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/Examples/MullersReucrrenceExample/MullersReucrrenceExample.csproj
+++ b/Examples/MullersReucrrenceExample/MullersReucrrenceExample.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9D9EF991-5E69-4B10-ACA7-0C0013E856B0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MullersReucrrenceExample</RootNamespace>
+    <AssemblyName>MullersReucrrenceExample</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\BigRational\BigRational.csproj">
+      <Project>{777ea875-cc5b-48b0-b968-a5555c3dc412}</Project>
+      <Name>BigRational</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Examples/MullersReucrrenceExample/Program.cs
+++ b/Examples/MullersReucrrenceExample/Program.cs
@@ -1,0 +1,148 @@
+﻿using ExtendedNumerics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MullersReucrrenceExample
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			int iterationCount = 141;
+			List<string>[] matrix = new[] {
+				InterationsList(iterationCount,11).ToList(),
+				MullersRecurrence<float>(iterationCount,10).ToList(),
+				MullersRecurrence<double>(iterationCount,20).ToList(),
+				MullersRecurrence<decimal>(iterationCount,31).ToList(),
+				MullersRecurrence<BigRational>(iterationCount,31).ToList()
+			};
+			for (int y = 0; y < iterationCount; ++y)
+			{
+				for (int x = 0; x < matrix.Length; ++x)
+				{
+					Console.Write($" {matrix[x][y]}");
+				}
+				Console.WriteLine();
+			}
+			Console.WriteLine();
+			Console.WriteLine("Press Enter To Continue");
+			Console.ReadLine();
+		}
+
+		public static IEnumerable<string> InterationsList(int iterations, int stringLength)
+		{
+			yield return "Iterations".PadRight(stringLength);
+			for (int i = 1; i < iterations; ++i)
+			{
+				yield return i.ToString().PadLeft(3).PadRight(stringLength);
+			}
+		}
+
+		public static IEnumerable<string> MullersRecurrence<T>(int iterations, int stringLength)
+		{
+			string typeString = typeof(T).ToString();
+			yield return $"{typeString.Substring(typeString.LastIndexOf('.')+1)}".PadRight(stringLength);
+			T c108 = Convert<T>(108d);
+			T c815 = Convert<T>(815d);
+			T c1500 = Convert<T>(1500d);
+
+			T x0 = Convert<T>(4d);
+			T x1 = Convert<T>(4.25d);
+
+			yield return FormatString(x0, stringLength);
+			yield return FormatString(x1, stringLength);
+
+			for (int i = 3; i < iterations; ++i)
+			{
+				// c108 - ((c185 - 1500 / x0) / x1);
+				T part1 = Divide(c1500, x0);
+				T part2 = Subtract(c815, part1);
+				T part3 = Divide(part2, x1);
+				T part4 = Subtract(c108, part3);
+
+				T xNext = part4;
+
+				yield return FormatString(xNext, stringLength);
+
+				x0 = x1;
+				x1 = xNext;
+			}
+		}
+
+		public static string FormatString<T>(T value, int stringLength)
+		{
+			// Convert the value to a 30 digit string, which equates to Decimal type
+			string stringValue = Convert<T, Decimal>(value).ToString();
+			int decimalPointPos = stringValue.IndexOf('.');
+			if (decimalPointPos<0)
+			{
+				stringValue = $"{stringValue}.0";
+				decimalPointPos = stringValue.IndexOf('.');
+			}
+			if (decimalPointPos < 3)
+			{
+				stringValue = stringValue.PadLeft(stringValue.Length + 3 - decimalPointPos);
+			}
+			if (stringValue.Length < stringLength)
+			{
+				stringValue = stringValue.PadRight(stringLength);
+			}
+			return stringValue;
+		}
+
+
+		public static T Convert<T>(double a) => Convert<double, T>(a);
+		public static T2 Convert<T1, T2>(T1 a)
+		{
+			return ConvertImplementation<T1, T2>.Function(a);
+		}
+		internal static class ConvertImplementation<T1, T2>
+		{
+			internal static Func<T1, T2> Function = (T1 a) =>
+			{
+				ParameterExpression A = Expression.Parameter(typeof(T1));
+				Expression BODY = Expression.Convert(A, typeof(T2));
+				Function = Expression.Lambda<Func<T1, T2>>(BODY, A).Compile();
+				return Function(a);
+			};
+		}
+
+		public static T Subtract<T>(T a, T b)
+		{
+			return SubtractImplementation<T>.Function(a, b);
+		}
+
+		internal static class SubtractImplementation<T>
+		{
+			internal static Func<T, T, T> Function = (T a, T b) =>
+			{
+				ParameterExpression A = Expression.Parameter(typeof(T));
+				ParameterExpression B = Expression.Parameter(typeof(T));
+				Expression BODY = Expression.Subtract(A, B);
+				Function = Expression.Lambda<Func<T, T, T>>(BODY, A, B).Compile();
+				return Function(a, b);
+			};
+		}
+
+		public static T Divide<T>(T a, T b)
+		{
+			return DivideImplementation<T>.Function(a, b);
+		}
+
+		internal static class DivideImplementation<T>
+		{
+			internal static Func<T, T, T> Function = (T a, T b) =>
+			{
+				ParameterExpression A = Expression.Parameter(typeof(T));
+				ParameterExpression B = Expression.Parameter(typeof(T));
+				Expression BODY = Expression.Divide(A, B);
+				Function = Expression.Lambda<Func<T, T, T>>(BODY, A, B).Compile();
+				return Function(a, b);
+			};
+		}
+	}
+}

--- a/Examples/MullersReucrrenceExample/Properties/AssemblyInfo.cs
+++ b/Examples/MullersReucrrenceExample/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MullersReucrrenceExample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MullersReucrrenceExample")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9d9ef991-5e69-4b10-aca7-0c0013e856b0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This compares float, double, decimal and BigRational using Muller's Recurrence which I've used before in a test. The code uses some interesting constructs to allow the number type to be used as a generic. Potentially the code could be modified to generate Markdown code that could be added to the readme to show the functionality of BigRational. Note this depends on my previous pull request that adds the conversion from BigRational to a decimal type.